### PR TITLE
[DEV-1]: Remove `@typescript-eslint/explicit-function-return-type` from the TypeScript configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # 📝 Changelog
 
+## [1.2.2] - 2025-02-20
+
+### 🔄 Updates
+
+- **TypeScript Configuration Cleanup**  
+  Removed `@typescript-eslint/explicit-function-return-type` from the TypeScript configuration file to simplify code readability and developer experience.  
+  [🔗 PR #10](https://github.com/kiforks/eslint-config/pull/10) by [@kiforks](https://github.com/kiforks)
+
+---
+
 ## [1.2.1] - 2025-02-12
 
 ### ✨ New Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@kiforks/eslint-config",
 	"description": "eslint shareable config",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"engines": {
 		"node": ">=20.8.1"
 	},

--- a/typescript.js
+++ b/typescript.js
@@ -24,7 +24,6 @@ const config = [
 			'@typescript-eslint/await-thenable': 'error',
 			'@typescript-eslint/no-confusing-void-expression': ['error', { ignoreArrowShorthand: true }],
 			'@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
-			'@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
 			'@typescript-eslint/ban-ts-comment': [
 				'error',
 				{


### PR DESCRIPTION
## Description

Removed `@typescript-eslint/explicit-function-return-type` from the TypeScript configuration file to simplify code readability and developer experience.  

## Checklist

- [x] **Clear and concise description** of the changes.
- [x] **Changelog updated** (if the changes affect users).
- [x] **Code review completed** for readability and maintainability.
- [x] **Impact assessment** done to identify potential side effects.
- [x] **Documentation updated** if the changes alter usage or behavior.
